### PR TITLE
fix/93/add-translation-for-status-left

### DIFF
--- a/gallehr/fixtures/translation.json
+++ b/gallehr/fixtures/translation.json
@@ -1,0 +1,15 @@
+[
+ {
+  "context": "Employee",
+  "contributed": 0,
+  "contribution_docname": null,
+  "contribution_status": "",
+  "docstatus": 0,
+  "doctype": "Translation",
+  "language": "de",
+  "modified": "2025-07-21 10:45:26.242228",
+  "name": "qm6gmlespa",
+  "source_text": "Left",
+  "translated_text": "Ausgeschieden"
+ }
+]

--- a/gallehr/hooks.py
+++ b/gallehr/hooks.py
@@ -14,8 +14,13 @@ doctype_js = {
 }
 fixtures = [
 	{"dt": "Print Format", "filters": 
-  		[
-        	["module", "=", "Gallehr"]
-        ]
-    }
+		[
+			["module", "=", "Gallehr"]
+		]
+	},
+	{"dt": "Translation", "filters": 
+		[
+            ["source_text", "in", ["Left"]]
+		]
+	}
 ]


### PR DESCRIPTION
## Description
Added Translation for Employee Doctype' s status "Left"

**Key changes:**##
* Added translation via Translation doctype with context "Employee"
* Added entry in hooks.py to export fixture in custom app

**Related issue(s)/ticket(s):**
* [GitLab Parent Issue](https://git.phamos.eu/gallehr/gallehr/-/issues/90) 
* [GitLab issue:](https://git.phamos.eu/gallehr/gallehr/-/issues/93) 

**Testing done:**
* Manual Testing

**Screenshot:**
<img width="1210" height="454" alt="image" src="https://github.com/user-attachments/assets/ae046007-7a69-4fe3-bfa5-227964a14ea8" />
<img width="1164" height="398" alt="ksnip_20250721-140549" src="https://github.com/user-attachments/assets/9d4383b4-6112-4ff1-bd61-235ac92ae22e" />

**Checklist:**
* [X] I followed this (guideline)[https://doku.phamos.eu/books/developer-onboarding/page/pull-request-creation]
* [X] I created feature branch from develop
* [X] The name of the feature branch follows conventions
* [X] I created logical commit with a clear messages
* [X] I pulled the changes from develop (again) and resolve possible conflicts
* [X] I pushed changes to remote feature branch
* [X] I created a Pull Request with title and description as described in the guideline
* [X] I checked if there is any conflict after creating the PR