### PR TITLE
refactor(finanz-dashboard): rework KPIs, fix Liquidität, add Netto trace

### DIFF
--- a/gallehr/gallehr/page/finanz_dashboard/finanz_dashboard.css
+++ b/gallehr/gallehr/page/finanz_dashboard/finanz_dashboard.css
@@ -1,48 +1,199 @@
-.finanz-dashboard { padding: 16px; font-family: var(--font-stack); }
+.finanz-dashboard {
+    padding: 16px;
+    font-family: var(--font-stack);
+}
 
-.fd-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 14px; }
-.fd-title { font-size: 18px; font-weight: 500; margin: 0; }
+.fd-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 14px;
+}
 
-.fd-filters { display: flex; gap: 12px; flex-wrap: wrap; align-items: flex-end; padding: 12px 14px; background: var(--card-bg); border: 1px solid var(--border-color); border-radius: var(--border-radius); margin-bottom: 14px; }
-.fd-fg { display: flex; flex-direction: column; gap: 4px; }
-.fd-fg label { font-size: 11px; color: var(--text-muted); }
-.fd-fg .form-control { min-width: 110px; font-size: 12px; }
+.fd-title {
+    font-size: 18px;
+    font-weight: 500;
+    margin: 0;
+}
 
-.fd-kpi-row { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 10px; margin-bottom: 10px; }
-.fd-kpi-card { background: var(--card-bg); border: 1px solid var(--border-color); border-top: 3px solid var(--border-color); border-radius: var(--border-radius); padding: 12px 14px; }
-.fd-border-blue { border-top-color: #378ADD !important; }
-.fd-border-amber { border-top-color: #BA7517 !important; }
-.fd-border-red { border-top-color: #E24B4A !important; }
-.fd-border-green { border-top-color: #639922 !important; }
-.fd-border-purple { border-top-color: #534AB7 !important; }
-.fd-kpi-label { font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.4px; margin-bottom: 6px; }
-.fd-kpi-val { font-size: 17px; font-weight: 500; line-height: 1.1; }
-.fd-kpi-sub { font-size: 10px; color: var(--text-muted); margin-top: 3px; }
+.fd-filters {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    padding: 12px 14px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    margin-bottom: 14px;
+}
 
-.fd-color-blue { color: #378ADD !important; }
-.fd-color-amber { color: #BA7517 !important; }
-.fd-color-red { color: #E24B4A !important; }
-.fd-color-green { color: #639922 !important; }
-.fd-color-purple { color: #534AB7 !important; }
+.fd-fg {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
 
-.fd-bottom-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 14px; }
-.fd-info-box { background: var(--card-bg); border: 1px solid var(--border-color); border-radius: var(--border-radius); padding: 14px; }
-.fd-info-title { display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.4px; margin-bottom: 10px; }
-.fd-link { font-size: 10px; color: #378ADD; text-decoration: none; text-transform: none; letter-spacing: 0; }
+.fd-fg label {
+    font-size: 11px;
+    color: var(--text-muted);
+}
 
-.fd-row { display: flex; justify-content: space-between; align-items: center; padding: 7px 0; border-bottom: 1px solid var(--border-color); font-size: 12px; }
-.fd-row:last-child { border-bottom: none; }
-.fd-row-total .fd-row-label { font-weight: 500; color: var(--text-color); }
-.fd-row-label { color: var(--text-muted); }
-.fd-row-val { font-weight: 500; }
-.fd-badge { background: var(--bg-color); border: 1px solid var(--border-color); border-radius: 4px; padding: 1px 5px; font-size: 10px; color: var(--text-muted); margin-left: 4px; }
-.fd-loading { color: var(--text-muted); font-size: 12px; padding: 10px 0; }
+.fd-fg .form-control {
+    min-width: 110px;
+    font-size: 12px;
+}
 
-.fd-charts-row { display: grid; grid-template-columns: 2fr 1fr; gap: 10px; }
-.fd-chart-box { background: var(--card-bg); border: 1px solid var(--border-color); border-radius: var(--border-radius); padding: 14px; }
-.fd-chart-title { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.4px; margin-bottom: 8px; }
-.fd-chart-wrap { position: relative; height: 220px; }
+/* ── ROW 1: two info-boxes side by side ── */
+.fd-top-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    margin-bottom: 10px;
+}
 
-.fd-legend { display: flex; gap: 12px; margin-bottom: 8px; font-size: 11px; color: var(--text-muted); flex-wrap: wrap; }
-.fd-legend span { display: flex; align-items: center; gap: 4px; }
-.fd-dot { width: 10px; height: 10px; border-radius: 2px; flex-shrink: 0; display: inline-block; }
+/* ── ROW 2: quotations + outstanding (unchanged) ── */
+.fd-bottom-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    margin-bottom: 14px;
+}
+
+.fd-info-box {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    padding: 14px;
+}
+
+.fd-info-title {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 11px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    margin-bottom: 10px;
+}
+
+.fd-link {
+    font-size: 10px;
+    color: #378ADD;
+    text-decoration: none;
+    text-transform: none;
+    letter-spacing: 0;
+}
+
+.fd-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 7px 0;
+    border-bottom: 1px solid var(--border-color);
+    font-size: 12px;
+}
+
+.fd-row:last-child {
+    border-bottom: none;
+}
+
+.fd-row-total .fd-row-label {
+    font-weight: 500;
+    color: var(--text-color);
+}
+
+.fd-row-label {
+    color: var(--text-muted);
+}
+
+.fd-row-val {
+    font-weight: 500;
+}
+
+.fd-badge {
+    background: var(--bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    padding: 1px 5px;
+    font-size: 10px;
+    color: var(--text-muted);
+    margin-left: 4px;
+}
+
+.fd-loading {
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 10px 0;
+}
+
+.fd-color-blue {
+    color: #378ADD !important;
+}
+
+.fd-color-amber {
+    color: #BA7517 !important;
+}
+
+.fd-color-red {
+    color: #E24B4A !important;
+}
+
+.fd-color-green {
+    color: #639922 !important;
+}
+
+.fd-color-purple {
+    color: #534AB7 !important;
+}
+
+/* ── CHARTS ── */
+.fd-charts-row {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 10px;
+}
+
+.fd-chart-box {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    padding: 14px;
+}
+
+.fd-chart-title {
+    font-size: 11px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    margin-bottom: 8px;
+}
+
+.fd-chart-wrap {
+    position: relative;
+    height: 220px;
+}
+
+.fd-legend {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 8px;
+    font-size: 11px;
+    color: var(--text-muted);
+    flex-wrap: wrap;
+}
+
+.fd-legend span {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.fd-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    flex-shrink: 0;
+    display: inline-block;
+}

--- a/gallehr/gallehr/page/finanz_dashboard/finanz_dashboard.html
+++ b/gallehr/gallehr/page/finanz_dashboard/finanz_dashboard.html
@@ -30,44 +30,58 @@
     <button class="btn btn-sm btn-primary fd-apply-btn">Anwenden</button>
   </div>
 
-  <!-- ROW 1: Umsatz Ist, Umsatz Soll, Liquidität -->
-  <div class="fd-kpi-row fd-kpi-row-1" id="fd-kpi-row-1"></div>
+  <!-- ROW 1: Umsatz (left) + Liquidität & Runway (right) -->
+  <div class="fd-top-row">
+    <div class="fd-info-box">
+      <div class="fd-info-title"><span>Umsatz</span></div>
+      <div id="fd-umsatz-rows">
+        <div class="fd-loading">Laden...</div>
+      </div>
+    </div>
+    <div class="fd-info-box">
+      <div class="fd-info-title"><span>Liquidität &amp; Runway</span></div>
+      <div id="fd-liq-rows">
+        <div class="fd-loading">Laden...</div>
+      </div>
+    </div>
+  </div>
 
-  <!-- ROW 2: Tage ohne Zahlung, Reale Lücke, Vorr. Lücke -->
-  <div class="fd-kpi-row fd-kpi-row-2" id="fd-kpi-row-2"></div>
-
-  <!-- ROW 3: Offene Angebote + Outstanding -->
+  <!-- ROW 2: Offene Angebote + Outstanding -->
   <div class="fd-bottom-row">
     <div class="fd-info-box">
       <div class="fd-info-title">
         <span>Offene Angebote</span>
         <a href="/app/quotation" target="_blank" class="fd-link">→ Alle anzeigen</a>
       </div>
-      <div id="fd-angebote-rows"><div class="fd-loading">Laden...</div></div>
+      <div id="fd-angebote-rows">
+        <div class="fd-loading">Laden...</div>
+      </div>
     </div>
     <div class="fd-info-box">
       <div class="fd-info-title">
         <span>Outstanding Aufträge</span>
         <a href="/app/query-report/Outstanding%20Report" target="_blank" class="fd-link">→ Zum Bericht</a>
       </div>
-      <div id="fd-outstanding-rows"><div class="fd-loading">Laden...</div></div>
+      <div id="fd-outstanding-rows">
+        <div class="fd-loading">Laden...</div>
+      </div>
     </div>
   </div>
 
-  <!-- ROW 4: Charts -->
+  <!-- ROW 3: Charts -->
   <div class="fd-charts-row">
-    <div class="fd-chart-box fd-chart-large">
-      <div class="fd-chart-title">G&amp;V — Einnahmen / Ausgaben / Liquidität</div>
+    <div class="fd-chart-box">
+      <div class="fd-chart-title">G&amp;V — Einnahmen / Ausgaben / Liquidität (Netto)</div>
       <div class="fd-legend" id="fd-legend-gv"></div>
       <div class="fd-chart-wrap">
-        <canvas id="fd-chart-gv" role="img" aria-label="G&V Monatsverlauf">Monatliche Einnahmen, Ausgaben und Liquiditaet.</canvas>
+        <canvas id="fd-chart-gv" role="img" aria-label="G&V Monatsverlauf"></canvas>
       </div>
     </div>
-    <div class="fd-chart-box fd-chart-small">
-      <div class="fd-chart-title">Burnrate / Monat</div>
+    <div class="fd-chart-box">
+      <div class="fd-chart-title">Burnrate / Monat (Netto)</div>
       <div class="fd-legend" id="fd-legend-burn"></div>
       <div class="fd-chart-wrap">
-        <canvas id="fd-chart-burn" role="img" aria-label="Monatliche Burnrate">Burnrate pro Monat.</canvas>
+        <canvas id="fd-chart-burn" role="img" aria-label="Monatliche Burnrate"></canvas>
       </div>
     </div>
   </div>

--- a/gallehr/gallehr/page/finanz_dashboard/finanz_dashboard.js
+++ b/gallehr/gallehr/page/finanz_dashboard/finanz_dashboard.js
@@ -1,4 +1,4 @@
-frappe.pages['finanz-dashboard'].on_page_load = function(wrapper) {
+frappe.pages['finanz-dashboard'].on_page_load = function (wrapper) {
 	var page = frappe.ui.make_app_page({
 		parent: wrapper,
 		title: 'Finanz Dashboard',
@@ -15,7 +15,7 @@ frappe.pages['finanz-dashboard'].on_page_load = function(wrapper) {
 
 	var script = document.createElement('script');
 	script.src = '/assets/gallehr/js/chart.umd.min.js';
-	script.onload = function() {
+	script.onload = function () {
 		window.fd_chart_js_loaded = true;
 		if (window.fd_chart_data) {
 			buildGVChart(window.fd_chart_data.labels, window.fd_chart_data.einnahmen, window.fd_chart_data.ausgaben, window.fd_chart_data.liquiditaet);
@@ -26,7 +26,7 @@ frappe.pages['finanz-dashboard'].on_page_load = function(wrapper) {
 };
 
 function bindEvents() {
-	$(document).on('click', '.fd-apply-btn, .fd-refresh-btn', function() {
+	$(document).on('click', '.fd-apply-btn, .fd-refresh-btn', function () {
 		loadAll();
 	});
 }
@@ -72,7 +72,7 @@ function loadReport() {
 			filters: filters,
 			ignore_prepared_report: true
 		},
-		callback: function(r) {
+		callback: function (r) {
 			if (!r.message) return;
 			processReport(r.message.columns, r.message.result, filters.jahr);
 		}
@@ -80,11 +80,11 @@ function loadReport() {
 }
 
 function processReport(columns, rows, jahr) {
-	var MONTHS = ['Jan','Feb','Mar','Apr','Mai','Jun','Jul','Aug','Sep','Okt','Nov','Dez'];
+	var MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'];
 	var monthlyRows = [];
 	var prognoseMap = {};
 
-	(rows || []).forEach(function(row) {
+	(rows || []).forEach(function (row) {
 		var monat = row.monat !== undefined ? row.monat : row[0];
 		var yearVal = row.jahr !== undefined ? row.jahr : row[1];
 		if (String(yearVal) === String(jahr) && MONTHS.indexOf(monat) !== -1) {
@@ -96,7 +96,7 @@ function processReport(columns, rows, jahr) {
 
 	function peur(label) {
 		var found = null;
-		Object.keys(prognoseMap).forEach(function(k) {
+		Object.keys(prognoseMap).forEach(function (k) {
 			if (k.indexOf(label) !== -1) { found = prognoseMap[k]; }
 		});
 		return found ? (found.prognose_eur !== undefined ? found.prognose_eur : (found[2] || 0)) : 0;
@@ -104,7 +104,7 @@ function processReport(columns, rows, jahr) {
 
 	function pzahl(label) {
 		var found = null;
-		Object.keys(prognoseMap).forEach(function(k) {
+		Object.keys(prognoseMap).forEach(function (k) {
 			if (k.indexOf(label) !== -1) { found = prognoseMap[k]; }
 		});
 		return found ? (found.prognose_zahl !== undefined ? found.prognose_zahl : (found[3] || 0)) : 0;
@@ -112,39 +112,41 @@ function processReport(columns, rows, jahr) {
 
 	var ist = peur('Umsatz Ist');
 	var soll = peur('Umsatz Soll');
-	var liq = peur('Liquiditaet aktuell');
+	var vorrLuecke = peur('Vorraussichtliche');
+	var liqNetto = peur('Liquiditaet aktuell (Netto');
+	var burnTag = peur('Burnrate/Tag verwendet');
+	var burnM = burnTag * 30;
 	var tage = pzahl('Tage ohne');
 	var monate = pzahl('Monate ohne');
-	var realLuecke = peur('Reale Umsatz');
-	var vorrLuecke = peur('Vorraussichtliche');
 
-	// ROW 1: Umsatz Ist, Umsatz Soll, Liquidität
-	var row1Html = [
-		kpiCard('Umsatz Ist (YTD)', fmt(ist), 'Einnahmen seit Jahresbeginn', 'green', ''),
-		kpiCard('Umsatz Soll', fmt(soll), 'Netto / Jahr', 'purple', ''),
-		kpiCard('Liquidität aktuell', fmt(liq), 'Netto', 'blue', '')
-	].join('');
-	$('#fd-kpi-row-1').html(row1Html);
+	// ── LEFT: Umsatz ──
+	var lueckeClass = vorrLuecke > 0 ? 'fd-color-red' : 'fd-color-green';
+	$('#fd-umsatz-rows').html(
+		row('Umsatz Ist (YTD)', fmt(ist), 'fd-color-green') +
+		row('Umsatz Soll', fmt(soll), 'fd-color-purple') +
+		rowTotal('Vorr. Umsatzlücke', fmt(vorrLuecke), lueckeClass)
+	);
 
-	// ROW 2: Tage ohne Zahlung, Reale Lücke, Vorr. Lücke
-	var row2Html = [
-		kpiCard('Tage ohne Zahlung', fmtN(tage, 0) + ' Tage', fmtN(monate, 1) + ' Monate', 'amber', 'amber'),
-		kpiCard('Reale Umsatzlücke', fmt(realLuecke), 'Soll − Ist − Outstanding', 'red', realLuecke > 0 ? 'red' : 'green'),
-		kpiCard('Vorr. Umsatzlücke', fmt(vorrLuecke), 'nach Angebotsumwandlung', vorrLuecke > 0 ? 'red' : 'green', vorrLuecke > 0 ? 'red' : 'green')
-	].join('');
-	$('#fd-kpi-row-2').html(row2Html);
+	// ── RIGHT: Liquidität & Runway ──
+	$('#fd-liq-rows').html(
+		row('Liquidität aktuell (Netto)', fmt(liqNetto), 'fd-color-blue') +
+		row('Tage ohne Zahlung', fmtN(tage, 0) + ' Tage / ' + fmtN(monate, 1) + ' Monate', 'fd-color-amber') +
+		row('Burnrate / Tag (Netto)', fmt(burnTag, 2), 'fd-color-purple') +
+		rowTotal('Burnrate / Monat (Netto)', fmt(burnM), 'fd-color-purple')
+	);
 
-	var activeMonths = monthlyRows.filter(function(r) {
+	// ── CHART DATA ──
+	var activeMonths = monthlyRows.filter(function (r) {
 		var ein = r.einnahmen_brutto !== undefined ? r.einnahmen_brutto : (r[4] || 0);
 		var aus = r.ausgaben_brutto !== undefined ? r.ausgaben_brutto : (r[5] || 0);
 		return ein > 0 || aus > 0;
 	});
 
-	var labels = activeMonths.map(function(r) { return r.monat !== undefined ? r.monat : r[0]; });
-	var einnahmen = activeMonths.map(function(r) { return r.einnahmen_brutto !== undefined ? r.einnahmen_brutto : (r[4] || 0); });
-	var ausgaben = activeMonths.map(function(r) { return r.ausgaben_brutto !== undefined ? r.ausgaben_brutto : (r[5] || 0); });
-	var liquiditaet = activeMonths.map(function(r) { return r.liq_brutto !== undefined ? r.liq_brutto : (r[7] || 0); });
-	var burnrate = activeMonths.map(function(r) { return r.burnrate_m !== undefined ? r.burnrate_m : (r[11] || 0); });
+	var labels = activeMonths.map(function (r) { return r.monat !== undefined ? r.monat : r[0]; });
+	var einnahmen = activeMonths.map(function (r) { return r.einnahmen_brutto !== undefined ? r.einnahmen_brutto : (r[4] || 0); });
+	var ausgaben = activeMonths.map(function (r) { return r.ausgaben_brutto !== undefined ? r.ausgaben_brutto : (r[5] || 0); });
+	var liquiditaet = activeMonths.map(function (r) { return r.liquiditaet_netto !== undefined ? r.liquiditaet_netto : (r[8] || 0); });
+	var burnrate = activeMonths.map(function (r) { return r.burnrate_m !== undefined ? r.burnrate_m : (r[12] || 0); });
 
 	window.fd_chart_data = { labels: labels, einnahmen: einnahmen, ausgaben: ausgaben, liquiditaet: liquiditaet, burnrate: burnrate };
 
@@ -154,11 +156,17 @@ function processReport(columns, rows, jahr) {
 	}
 }
 
-function kpiCard(label, value, sub, borderColor, valueColor) {
-	return '<div class="fd-kpi-card fd-border-' + borderColor + '">' +
-		'<div class="fd-kpi-label">' + label + '</div>' +
-		'<div class="fd-kpi-val' + (valueColor ? ' fd-color-' + valueColor : '') + '">' + value + '</div>' +
-		'<div class="fd-kpi-sub">' + sub + '</div>' +
+function row(label, val, valClass) {
+	return '<div class="fd-row">' +
+		'<span class="fd-row-label">' + label + '</span>' +
+		'<span class="fd-row-val ' + (valClass || '') + '">' + val + '</span>' +
+		'</div>';
+}
+
+function rowTotal(label, val, valClass) {
+	return '<div class="fd-row fd-row-total">' +
+		'<span class="fd-row-label">' + label + '</span>' +
+		'<span class="fd-row-val ' + (valClass || '') + '">' + val + '</span>' +
 		'</div>';
 }
 
@@ -169,16 +177,16 @@ function buildGVChart(labels, einnahmen, ausgaben, liquiditaet) {
 	$('#fd-legend-gv').html(
 		'<span><span class="fd-dot" style="background:#639922"></span>Einnahmen</span>' +
 		'<span><span class="fd-dot" style="background:#E24B4A"></span>Ausgaben</span>' +
-		'<span><span class="fd-dot" style="background:#378ADD"></span>Liquidität</span>'
+		'<span><span class="fd-dot" style="background:#378ADD"></span>Liquidität Netto</span>'
 	);
 	window.fd_charts.gv = new Chart(ctx, {
 		type: 'line',
 		data: {
 			labels: labels,
 			datasets: [
-				{ label: 'Einnahmen', data: einnahmen, borderColor: '#639922', borderWidth: 2, pointRadius: 4, tension: 0.3, fill: false, borderDash: [] },
-				{ label: 'Ausgaben', data: ausgaben, borderColor: '#E24B4A', borderWidth: 2, pointRadius: 4, tension: 0.3, fill: false, borderDash: [4,3] },
-				{ label: 'Liquidität', data: liquiditaet, borderColor: '#378ADD', borderWidth: 2.5, pointRadius: 4, tension: 0.3, fill: false, borderDash: [8,3] }
+				{ label: 'Einnahmen', data: einnahmen, borderColor: '#639922', borderWidth: 2, pointRadius: 4, tension: 0.3, fill: false },
+				{ label: 'Ausgaben', data: ausgaben, borderColor: '#E24B4A', borderWidth: 2, pointRadius: 4, tension: 0.3, fill: false, borderDash: [4, 3] },
+				{ label: 'Liquidität Netto', data: liquiditaet, borderColor: '#378ADD', borderWidth: 2.5, pointRadius: 4, tension: 0.3, fill: false, borderDash: [8, 3] }
 			]
 		},
 		options: chartOptions()
@@ -189,7 +197,7 @@ function buildBurnChart(labels, burnrate) {
 	if (window.fd_charts && window.fd_charts.burn) { window.fd_charts.burn.destroy(); }
 	var ctx = document.getElementById('fd-chart-burn');
 	if (!ctx) return;
-	$('#fd-legend-burn').html('<span><span class="fd-dot" style="background:#534AB7"></span>Burnrate/M</span>');
+	$('#fd-legend-burn').html('<span><span class="fd-dot" style="background:#534AB7"></span>Burnrate/M Netto</span>');
 	window.fd_charts.burn = new Chart(ctx, {
 		type: 'line',
 		data: {
@@ -205,15 +213,23 @@ function chartOptions() {
 		responsive: true, maintainAspectRatio: false,
 		plugins: {
 			legend: { display: false },
-			tooltip: { callbacks: { label: function(ctx) {
-				return ctx.dataset.label + ': ' + new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(ctx.raw);
-			}}}
+			tooltip: {
+				callbacks: {
+					label: function (ctx) {
+						return ctx.dataset.label + ': ' + new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(ctx.raw);
+					}
+				}
+			}
 		},
 		scales: {
 			x: { ticks: { color: '#888', font: { size: 11 } }, grid: { color: 'rgba(128,128,128,0.15)' } },
-			y: { ticks: { color: '#888', font: { size: 11 }, callback: function(v) {
-				return new Intl.NumberFormat('de-DE', { notation: 'compact', maximumFractionDigits: 0 }).format(v);
-			}}, grid: { color: 'rgba(128,128,128,0.15)' } }
+			y: {
+				ticks: {
+					color: '#888', font: { size: 11 }, callback: function (v) {
+						return new Intl.NumberFormat('de-DE', { notation: 'compact', maximumFractionDigits: 0 }).format(v);
+					}
+				}, grid: { color: 'rgba(128,128,128,0.15)' }
+			}
 		}
 	};
 }
@@ -230,12 +246,12 @@ function loadAngebote() {
 			],
 			limit: 500
 		},
-		callback: function(r) {
+		callback: function (r) {
 			if (!r.message) return;
 			var byCompany = {};
 			var total = 0;
 			var totalCount = 0;
-			r.message.forEach(function(q) {
+			r.message.forEach(function (q) {
 				var co = q.company || 'Unbekannt';
 				if (!byCompany[co]) { byCompany[co] = { count: 0, total: 0 }; }
 				byCompany[co].count++;
@@ -244,7 +260,7 @@ function loadAngebote() {
 				totalCount++;
 			});
 			var html = '';
-			Object.keys(byCompany).forEach(function(co) {
+			Object.keys(byCompany).forEach(function (co) {
 				var d = byCompany[co];
 				html += '<div class="fd-row"><span class="fd-row-label">' + co + '<span class="fd-badge">' + d.count + '</span></span><span class="fd-row-val fd-color-blue">' + fmt(d.total) + '</span></div>';
 			});
@@ -258,7 +274,7 @@ function loadOutstanding() {
 	frappe.call({
 		method: 'frappe.desk.query_report.run',
 		args: { report_name: 'Outstanding Report', filters: {}, ignore_prepared_report: true },
-		callback: function(r) {
+		callback: function (r) {
 			if (!r.message || !r.message.result) {
 				$('#fd-outstanding-rows').html('<div class="fd-loading">Keine Daten</div>');
 				return;
@@ -266,7 +282,7 @@ function loadOutstanding() {
 			var rows = r.message.result;
 			var unbilled = 0;
 			var invoicedNotPaid = 0;
-			rows.forEach(function(row) {
+			rows.forEach(function (row) {
 				var type = row.type !== undefined ? row.type : row[10];
 				var unbilledAmt = row.unbilled_netto !== undefined ? row.unbilled_netto : (row[7] || 0);
 				var invoicedAmt = row.invoice_outstanding_netto !== undefined ? row.invoice_outstanding_netto : (row[8] || 0);
@@ -274,7 +290,8 @@ function loadOutstanding() {
 				else if (type === 'Invoiced Not Paid') { invoicedNotPaid += invoicedAmt; }
 			});
 			var total = unbilled + invoicedNotPaid;
-			var html = '<div class="fd-row"><span class="fd-row-label">Unbilled (nicht fakturiert)</span><span class="fd-row-val fd-color-blue">' + fmt(unbilled) + '</span></div>' +
+			var html =
+				'<div class="fd-row"><span class="fd-row-label">Unbilled (nicht fakturiert)</span><span class="fd-row-val fd-color-blue">' + fmt(unbilled) + '</span></div>' +
 				'<div class="fd-row"><span class="fd-row-label">Invoiced not paid</span><span class="fd-row-val fd-color-amber">' + fmt(invoicedNotPaid) + '</span></div>' +
 				'<div class="fd-row fd-row-total"><span class="fd-row-label">Total Expected (Netto)</span><span class="fd-row-val fd-color-green">' + fmt(total) + '</span></div>';
 			$('#fd-outstanding-rows').html(html);


### PR DESCRIPTION
Refactor Finanz Dashboard — Liquidität fix & layout overhaul

## What changed

**Report (Python)**
- Fixed Jan accumulation bug: `liquiditaet_brutto` now correctly adds
  saldo_brutto in month 1 instead of resetting to start_liq
- Added `liquiditaet_netto` column (= liq_brutto / 1.19) for full
  Brutto/Netto trace in the report table
- Runway calculation is now internally consistent: liq_brutto /
  burnrate_brutto (1.19 cancels out, same result as Netto/Netto)
- Added two separate prognose rows for Liquidität aktuell — Brutto and
  Netto — so both are visible when reading the raw report
- Removed prow() helper function (incompatible with Frappe safe_exec)

**Dashboard (JS/HTML/CSS)**
- Replaced the two KPI card rows with two plain info-box panels matching
  the existing Angebote/Outstanding style
- Left panel: Umsatz Ist, Umsatz Soll, Vorr. Umsatzlücke
- Right panel: Liquidität aktuell (Netto), Tage ohne Zahlung,
  Burnrate/Tag, Burnrate/Monat
- Chart G&V now plots liquiditaet_netto instead of the raw brutto value
- Removed all fd-kpi-* CSS classes (no longer needed)

## Why

The displayed Liquidität was Brutto but labelled as Netto — off by factor
1/1.19. Root cause: the column was accumulated correctly but never
divided. The fix keeps Brutto visible in the report for traceability
while the dashboard exclusively shows Netto values, consistent with all
other KPIs.