### PR TITLE
fix(finanz-dashboard): move page files to correct path, add JS to pub…

### DIFF
--- a/gallehr/page/finanz-dashboard/finanz_dashboard.css
+++ b/gallehr/page/finanz-dashboard/finanz_dashboard.css
@@ -1,0 +1,68 @@
+.finanz-dashboard { padding: 16px; font-family: var(--font-stack); }
+
+.fd-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 14px; }
+.fd-title { font-size: 18px; font-weight: 500; margin: 0; }
+
+.fd-filters { display: flex; gap: 12px; flex-wrap: wrap; align-items: flex-end; padding: 12px 14px; background: var(--card-bg); border: 1px solid var(--border-color); border-radius: var(--border-radius); margin-bottom: 14px; }
+.fd-fg { display: flex; flex-direction: column; gap: 4px; }
+.fd-fg label { font-size: 11px; color: var(--text-muted); }
+.fd-fg .form-control { min-width: 110px; font-size: 12px; }
+
+/* ── ROW 1: two info-boxes side by side ── */
+.fd-top-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 10px; }
+
+/* ── ROW 2: quotations + outstanding (unchanged) ── */
+.fd-bottom-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 14px; }
+
+.fd-info-box { background: var(--card-bg); border: 1px solid var(--border-color); border-radius: var(--border-radius); padding: 14px; }
+.fd-info-title { display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.4px; margin-bottom: 10px; }
+.fd-link { font-size: 10px; color: #378ADD; text-decoration: none; text-transform: none; letter-spacing: 0; }
+
+.fd-row { display: flex; justify-content: space-between; align-items: center; padding: 7px 0; border-bottom: 1px solid var(--border-color); font-size: 12px; }
+.fd-row:last-child { border-bottom: none; }
+.fd-row-total .fd-row-label { font-weight: 500; color: var(--text-color); }
+.fd-row-label { color: var(--text-muted); }
+.fd-row-val { font-weight: 500; }
+.fd-badge { background: var(--bg-color); border: 1px solid var(--border-color); border-radius: 4px; padding: 1px 5px; font-size: 10px; color: var(--text-muted); margin-left: 4px; }
+.fd-loading { color: var(--text-muted); font-size: 12px; padding: 10px 0; }
+
+.fd-color-blue   { color: #378ADD !important; }
+.fd-color-amber  { color: #BA7517 !important; }
+.fd-color-red    { color: #E24B4A !important; }
+.fd-color-green  { color: #639922 !important; }
+.fd-color-purple { color: #534AB7 !important; }
+
+/* ── CHARTS ── */
+.fd-charts-row { display: grid; grid-template-columns: 2fr 1fr; gap: 10px; }
+.fd-chart-box { background: var(--card-bg); border: 1px solid var(--border-color); border-radius: var(--border-radius); padding: 14px; }
+.fd-chart-title { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.4px; margin-bottom: 8px; }
+.fd-chart-wrap { position: relative; height: 220px; }
+
+.fd-legend { display: flex; gap: 12px; margin-bottom: 8px; font-size: 11px; color: var(--text-muted); flex-wrap: wrap; }
+.fd-legend span { display: flex; align-items: center; gap: 4px; }
+.fd-dot { width: 10px; height: 10px; border-radius: 2px; flex-shrink: 0; display: inline-block; }
+
+/* ── Snapshot / filter additions ── */
+.fd-fg-check { justify-content: flex-end; }
+.fd-check-label { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-color); cursor: pointer; padding: 5px 0; white-space: nowrap; }
+.fd-check-label input[type="checkbox"] { margin: 0; }
+.fd-sep { border-left: 1px solid var(--border-color); align-self: stretch; margin: 0 4px; }
+
+.fd-snap-notice { padding: 7px 12px; border-radius: var(--border-radius); font-size: 12px; margin-bottom: 10px; }
+.fd-snap-notice.info  { background: rgba(55,138,221,0.1); color: #378ADD; border: 1px solid rgba(55,138,221,0.3); }
+.fd-snap-notice.saved { background: rgba(99,153,34,0.1);  color: #639922; border: 1px solid rgba(99,153,34,0.3); }
+
+.fd-snap-box { margin-top: 14px; }
+.fd-snap-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.fd-snap-table th { text-align: left; color: var(--text-muted); font-weight: 400; font-size: 10px; text-transform: uppercase; letter-spacing: 0.4px; padding: 0 0 6px; border-bottom: 1px solid var(--border-color); }
+.fd-snap-table th:last-child { text-align: right; }
+.fd-snap-table td { padding: 7px 0; border-bottom: 1px solid var(--border-color); color: var(--text-muted); vertical-align: middle; }
+.fd-snap-table tr:last-child td { border-bottom: none; }
+.fd-snap-table td.val { font-weight: 500; color: var(--text-color); }
+.fd-snap-table td.std { text-align: center; }
+.fd-snap-table td.act { text-align: right; }
+.fd-snap-std-badge { background: rgba(99,153,34,0.12); color: #639922; border: 1px solid rgba(99,153,34,0.3); border-radius: 4px; padding: 1px 7px; font-size: 10px; }
+.fd-snap-del { background: none; border: none; color: var(--text-muted); cursor: pointer; font-size: 12px; padding: 2px 6px; border-radius: 4px; }
+.fd-snap-del:hover { background: rgba(226,75,74,0.1); color: #E24B4A; }
+.fd-snap-set { background: none; border: 1px solid var(--border-color); color: var(--text-muted); cursor: pointer; font-size: 11px; padding: 2px 8px; border-radius: 4px; margin-right: 4px; }
+.fd-snap-set:hover { border-color: #639922; color: #639922; }

--- a/gallehr/page/finanz-dashboard/finanz_dashboard.html
+++ b/gallehr/page/finanz-dashboard/finanz_dashboard.html
@@ -1,0 +1,103 @@
+<div class="finanz-dashboard">
+  <div class="fd-header">
+    <h4 class="fd-title">Finanz Dashboard</h4>
+    <button class="btn btn-sm btn-default fd-refresh-btn">
+      <i class="ti ti-refresh"></i> Aktualisieren
+    </button>
+  </div>
+
+  <div class="fd-filters">
+    <div class="fd-fg">
+      <label>Jahr</label>
+      <select id="fd-jahr" class="form-control form-control-sm">
+        <option value="2024">2024</option>
+        <option value="2025">2025</option>
+        <option value="2026" selected>2026</option>
+      </select>
+    </div>
+    <div class="fd-fg">
+      <label>Aktueller Kontostand (Brutto)</label>
+      <input type="number" id="fd-aktuell" class="form-control form-control-sm" placeholder="z.B. 300000">
+    </div>
+    <div class="fd-fg fd-fg-check">
+      <label>&nbsp;</label>
+      <label class="fd-check-label">
+        <input type="checkbox" id="fd-aktuell-save"> Als Standard speichern
+      </label>
+    </div>
+    <div class="fd-fg fd-sep"></div>
+    <div class="fd-fg">
+      <label>Start Liquidität Jan (Brutto)</label>
+      <input type="number" id="fd-liq" class="form-control form-control-sm" placeholder="Fallback">
+    </div>
+    <div class="fd-fg">
+      <label>Angebotsumwandlung %</label>
+      <input type="number" id="fd-umwandlung" class="form-control form-control-sm" value="30">
+    </div>
+    <div class="fd-fg">
+      <label>Burnrate/Tag (manuell)</label>
+      <input type="number" id="fd-burnrate" class="form-control form-control-sm" placeholder="leer = auto">
+    </div>
+    <button class="btn btn-sm btn-primary fd-apply-btn">Anwenden</button>
+  </div>
+
+  <div id="fd-snap-notice" class="fd-snap-notice" style="display:none"></div>
+
+  <!-- ROW 1: Umsatz + Liquidität & Runway -->
+  <div class="fd-top-row">
+    <div class="fd-info-box">
+      <div class="fd-info-title"><span>Umsatz</span></div>
+      <div id="fd-umsatz-rows"><div class="fd-loading">Laden...</div></div>
+    </div>
+    <div class="fd-info-box">
+      <div class="fd-info-title"><span>Liquidität &amp; Runway</span></div>
+      <div id="fd-liq-rows"><div class="fd-loading">Laden...</div></div>
+    </div>
+  </div>
+
+  <!-- ROW 2: Offene Angebote + Outstanding -->
+  <div class="fd-bottom-row">
+    <div class="fd-info-box">
+      <div class="fd-info-title">
+        <span>Offene Angebote</span>
+        <a href="/app/quotation" target="_blank" class="fd-link">→ Alle anzeigen</a>
+      </div>
+      <div id="fd-angebote-rows"><div class="fd-loading">Laden...</div></div>
+    </div>
+    <div class="fd-info-box">
+      <div class="fd-info-title">
+        <span>Outstanding Aufträge</span>
+        <a href="/app/query-report/Outstanding%20Report" target="_blank" class="fd-link">→ Zum Bericht</a>
+      </div>
+      <div id="fd-outstanding-rows"><div class="fd-loading">Laden...</div></div>
+    </div>
+  </div>
+
+  <!-- ROW 3: Charts -->
+  <div class="fd-charts-row">
+    <div class="fd-chart-box">
+      <div class="fd-chart-title">G&amp;V — Einnahmen / Ausgaben / Liquidität (Netto)</div>
+      <div class="fd-legend" id="fd-legend-gv"></div>
+      <div class="fd-chart-wrap">
+        <canvas id="fd-chart-gv" role="img" aria-label="G&V Monatsverlauf"></canvas>
+      </div>
+    </div>
+    <div class="fd-chart-box">
+      <div class="fd-chart-title">Burnrate / Monat (Netto)</div>
+      <div class="fd-legend" id="fd-legend-burn"></div>
+      <div class="fd-chart-wrap">
+        <canvas id="fd-chart-burn" role="img" aria-label="Monatliche Burnrate"></canvas>
+      </div>
+    </div>
+  </div>
+
+  <!-- ROW 4: Snapshot history -->
+  <div class="fd-info-box fd-snap-box">
+    <div class="fd-info-title">
+      <span>Liquidität Snapshots</span>
+      <a href="/app/liquiditaet-snapshot" target="_blank" class="fd-link">→ Alle verwalten</a>
+    </div>
+    <div id="fd-snap-rows"><div class="fd-loading">Laden...</div></div>
+  </div>
+
+</div>

--- a/gallehr/page/finanz-dashboard/finanz_dashboard.js
+++ b/gallehr/page/finanz-dashboard/finanz_dashboard.js
@@ -1,0 +1,435 @@
+frappe.pages['finanz-dashboard'].on_page_load = function (wrapper) {
+	var page = frappe.ui.make_app_page({
+		parent: wrapper,
+		title: 'Finanz Dashboard',
+		single_column: true
+	});
+
+	$(frappe.render_template('finanz_dashboard', {})).appendTo(page.body);
+
+	window.fd_charts = {};
+	window.fd_chart_js_loaded = false;
+
+	var script = document.createElement('script');
+	script.src = '/assets/gallehr/js/chart.umd.min.js';
+	script.onload = function () {
+		window.fd_chart_js_loaded = true;
+		if (window.fd_chart_data) {
+			buildGVChart(window.fd_chart_data.labels, window.fd_chart_data.einnahmen, window.fd_chart_data.ausgaben, window.fd_chart_data.liquiditaet);
+			buildBurnChart(window.fd_chart_data.labels, window.fd_chart_data.burnrate);
+		}
+	};
+	document.head.appendChild(script);
+
+	bindEvents();
+	loadSnapshots(function () { loadAll(); });
+};
+
+function bindEvents() {
+	$(document).on('click', '.fd-apply-btn, .fd-refresh-btn', function () {
+		var aktuell = parseFloat($('#fd-aktuell').val());
+		var save = $('#fd-aktuell-save').is(':checked');
+		if (aktuell > 0 && save) {
+			saveSnapshot(aktuell, function () { loadAll(); loadSnapshots(); });
+		} else {
+			loadAll();
+		}
+	});
+
+	$(document).on('click', '.fd-snap-del-btn', function () {
+		var name = $(this).data('name');
+		frappe.confirm('Snapshot löschen?', function () {
+			frappe.call({
+				method: 'frappe.client.delete',
+				args: { doctype: 'Liquiditaet Snapshot', name: name },
+				callback: function () { loadSnapshots(function () { loadAll(); }); }
+			});
+		});
+	});
+
+	$(document).on('click', '.fd-snap-set-btn', function () {
+		var name = $(this).data('name');
+		var val = parseFloat($(this).data('val'));
+		setDefaultSnapshot(name, val);
+	});
+}
+
+function getFilters() {
+	return {
+		jahr: $('#fd-jahr').val() || '2026',
+		aktuell_liquiditaet: parseFloat($('#fd-aktuell').val()) || 0,
+		start_liquiditaet: parseFloat($('#fd-liq').val()) || 0,
+		angebotsumwandlung: parseFloat($('#fd-umwandlung').val()) || 30,
+		avg_aus_tag_manuell: parseFloat($('#fd-burnrate').val()) || 0
+	};
+}
+
+function fmt(val, decimals) {
+	if (val === null || val === undefined || isNaN(val)) return '—';
+	decimals = decimals !== undefined ? decimals : 0;
+	return new Intl.NumberFormat('de-DE', {
+		style: 'currency', currency: 'EUR',
+		minimumFractionDigits: decimals, maximumFractionDigits: decimals
+	}).format(val);
+}
+
+function fmtN(val, decimals) {
+	if (val === null || val === undefined || isNaN(val)) return '—';
+	decimals = decimals !== undefined ? decimals : 1;
+	return new Intl.NumberFormat('de-DE', {
+		minimumFractionDigits: decimals, maximumFractionDigits: decimals
+	}).format(val);
+}
+
+function fmtDt(dt) {
+	if (!dt) return '—';
+	return frappe.datetime.str_to_user(dt.substring(0, 16));
+}
+
+// ── Snapshot persistence ──────────────────────────────────────────────────────
+
+function loadSnapshots(cb) {
+	frappe.call({
+		method: 'frappe.client.get_value',
+		args: { doctype: 'DocType', filters: { name: 'Liquiditaet Snapshot' }, fieldname: 'name' },
+		callback: function (r) {
+			if (!r.message || !r.message.name) {
+				$('#fd-snap-rows').html('<div class="fd-loading">Snapshots nicht verfügbar (bench migrate ausstehend)</div>');
+				if (cb) cb();
+				return;
+			}
+			frappe.call({
+				method: 'frappe.client.get_list',
+				args: {
+					doctype: 'Liquiditaet Snapshot',
+					fields: ['name', 'kontostand_brutto', 'datum', 'als_standard', 'notiz'],
+					order_by: 'datum desc',
+					limit: 50
+				},
+				callback: function (r) {
+					var snaps = r.message || [];
+					renderSnapshotTable(snaps);
+					var aktuelField = $('#fd-aktuell');
+					if (!aktuelField.val()) {
+						var def = null;
+						snaps.forEach(function (s) { if (s.als_standard) def = s; });
+						if (def) {
+							aktuelField.val(def.kontostand_brutto);
+							showNotice('Standard-Snapshot vom ' + fmtDt(def.datum) + ' geladen (' + fmt(def.kontostand_brutto) + ')', 'info');
+						}
+					}
+					if (cb) cb();
+				}
+			});
+		}
+	});
+}
+
+function saveSnapshot(val, cb) {
+	// Clear existing defaults first, then create new
+	frappe.call({
+		method: 'frappe.client.get_list',
+		args: { doctype: 'Liquiditaet Snapshot', filters: { als_standard: 1 }, fields: ['name'], limit: 50 },
+		callback: function (r) {
+			var prev = r.message || [];
+			var chain = prev.length;
+
+			function createNew() {
+				frappe.call({
+					method: 'frappe.client.insert',
+					args: {
+						doc: {
+							doctype: 'Liquiditaet Snapshot',
+							kontostand_brutto: val,
+							datum: frappe.datetime.now_datetime(),
+							als_standard: 1
+						}
+					},
+					callback: function () {
+						showNotice('Snapshot gespeichert und als Standard gesetzt (' + fmt(val) + ')', 'saved');
+						if (cb) cb();
+					}
+				});
+			}
+
+			if (chain === 0) {
+				createNew();
+			} else {
+				var done = 0;
+				prev.forEach(function (p) {
+					frappe.call({
+						method: 'frappe.client.set_value',
+						args: { doctype: 'Liquiditaet Snapshot', name: p.name, fieldname: 'als_standard', value: 0 },
+						callback: function () { done++; if (done === chain) createNew(); }
+					});
+				});
+			}
+		}
+	});
+}
+
+function setDefaultSnapshot(name, val) {
+	// Clear all defaults, set this one, prefill field
+	frappe.call({
+		method: 'frappe.client.get_list',
+		args: { doctype: 'Liquiditaet Snapshot', filters: { als_standard: 1 }, fields: ['name'], limit: 50 },
+		callback: function (r) {
+			var prev = r.message || [];
+			var done = 0;
+			var total = prev.length;
+
+			function finish() {
+				frappe.call({
+					method: 'frappe.client.set_value',
+					args: { doctype: 'Liquiditaet Snapshot', name: name, fieldname: 'als_standard', value: 1 },
+					callback: function () {
+						$('#fd-aktuell').val(val);
+						showNotice('Standard gesetzt: ' + fmt(val), 'saved');
+						loadSnapshots(function () { loadAll(); });
+					}
+				});
+			}
+
+			if (total === 0) { finish(); return; }
+			prev.forEach(function (p) {
+				frappe.call({
+					method: 'frappe.client.set_value',
+					args: { doctype: 'Liquiditaet Snapshot', name: p.name, fieldname: 'als_standard', value: 0 },
+					callback: function () { done++; if (done === total) finish(); }
+				});
+			});
+		}
+	});
+}
+
+function renderSnapshotTable(snaps) {
+	if (!snaps.length) {
+		$('#fd-snap-rows').html('<div class="fd-loading">Keine Snapshots vorhanden</div>');
+		return;
+	}
+	var html = '<table class="fd-snap-table">' +
+		'<thead><tr>' +
+		'<th>Datum</th><th>Kontostand Brutto</th><th>Standard</th><th style="text-align:right">Aktionen</th>' +
+		'</tr></thead><tbody>';
+	snaps.forEach(function (s) {
+		var stdBadge = s.als_standard
+			? '<span class="fd-snap-std-badge">Standard</span>'
+			: '<button class="fd-snap-set-btn" data-name="' + s.name + '" data-val="' + s.kontostand_brutto + '">Als Standard</button>';
+		html += '<tr>' +
+			'<td>' + fmtDt(s.datum) + '</td>' +
+			'<td class="val">' + fmt(s.kontostand_brutto) + '</td>' +
+			'<td class="std">' + stdBadge + '</td>' +
+			'<td class="act"><button class="fd-snap-del-btn fd-snap-del" data-name="' + s.name + '" title="Löschen">✕</button></td>' +
+			'</tr>';
+	});
+	html += '</tbody></table>';
+	$('#fd-snap-rows').html(html);
+}
+
+function showNotice(msg, type) {
+	$('#fd-snap-notice').removeClass('info saved').addClass(type).text(msg).show();
+	setTimeout(function () { $('#fd-snap-notice').fadeOut(400); }, 4000);
+}
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+function loadAll() {
+	loadReport();
+	loadAngebote();
+	loadOutstanding();
+}
+
+function loadReport() {
+	var filters = getFilters();
+	frappe.call({
+		method: 'frappe.desk.query_report.run',
+		args: { report_name: 'Finanz Dashboard', filters: filters, ignore_prepared_report: true },
+		callback: function (r) {
+			if (!r.message) return;
+			processReport(r.message.columns, r.message.result, filters.jahr);
+		}
+	});
+}
+
+function processReport(columns, rows, jahr) {
+	var MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'];
+	var monthlyRows = [];
+	var prognoseMap = {};
+
+	(rows || []).forEach(function (row) {
+		var monat = row.monat !== undefined ? row.monat : row[0];
+		var yearVal = row.jahr !== undefined ? row.jahr : row[1];
+		if (String(yearVal) === String(jahr) && MONTHS.indexOf(monat) !== -1) {
+			monthlyRows.push(row);
+		} else if (!yearVal && monat && monat !== '---') {
+			prognoseMap[monat] = row;
+		}
+	});
+
+	function peur(label) {
+		var found = null;
+		Object.keys(prognoseMap).forEach(function (k) { if (k.indexOf(label) !== -1) found = prognoseMap[k]; });
+		return found ? (found.prognose_eur !== undefined ? found.prognose_eur : (found[2] || 0)) : 0;
+	}
+	function pzahl(label) {
+		var found = null;
+		Object.keys(prognoseMap).forEach(function (k) { if (k.indexOf(label) !== -1) found = prognoseMap[k]; });
+		return found ? (found.prognose_zahl !== undefined ? found.prognose_zahl : (found[3] || 0)) : 0;
+	}
+
+	var ist = peur('Umsatz Ist');
+	var soll = peur('Umsatz Soll');
+	var vorrLuecke = peur('Vorraussichtliche');
+	var liqBrutto = peur('Liquiditaet aktuell');
+	var burnTag = peur('Burnrate/Tag verwendet');
+	var burnM = burnTag * 30;
+	var tage = pzahl('Tage ohne');
+	var monate = pzahl('Monate ohne');
+
+	var lueckeClass = vorrLuecke > 0 ? 'fd-color-red' : 'fd-color-green';
+	$('#fd-umsatz-rows').html(
+		row('Umsatz Ist (YTD)', fmt(ist), 'fd-color-green') +
+		row('Umsatz Soll', fmt(soll), 'fd-color-purple') +
+		rowTotal('Vorr. Umsatzlücke', fmt(vorrLuecke), lueckeClass)
+	);
+	$('#fd-liq-rows').html(
+		row('Liquidität aktuell (Brutto/Kontostand)', fmt(liqBrutto), 'fd-color-blue') +
+		row('Tage ohne Zahlung', fmtN(tage, 0) + ' Tage / ' + fmtN(monate, 1) + ' Monate', 'fd-color-amber') +
+		row('Burnrate / Tag (Netto)', fmt(burnTag, 2), 'fd-color-purple') +
+		rowTotal('Burnrate / Monat (Netto)', fmt(burnM), 'fd-color-purple')
+	);
+
+	var activeMonths = monthlyRows.filter(function (r) {
+		var ein = r.einnahmen_brutto !== undefined ? r.einnahmen_brutto : (r[4] || 0);
+		var aus = r.ausgaben_brutto !== undefined ? r.ausgaben_brutto : (r[5] || 0);
+		return ein > 0 || aus > 0;
+	});
+	var labels = activeMonths.map(function (r) { return r.monat !== undefined ? r.monat : r[0]; });
+	var einnahmen = activeMonths.map(function (r) { return r.einnahmen_brutto !== undefined ? r.einnahmen_brutto : (r[4] || 0); });
+	var ausgaben = activeMonths.map(function (r) { return r.ausgaben_brutto !== undefined ? r.ausgaben_brutto : (r[5] || 0); });
+	var liquiditaet = activeMonths.map(function (r) { return r.liquiditaet !== undefined ? r.liquiditaet : (r[7] || 0); });
+	var burnrate = activeMonths.map(function (r) { return r.burnrate_m !== undefined ? r.burnrate_m : (r[12] || 0); });
+
+	window.fd_chart_data = { labels: labels, einnahmen: einnahmen, ausgaben: ausgaben, liquiditaet: liquiditaet, burnrate: burnrate };
+	if (window.fd_chart_js_loaded) {
+		buildGVChart(labels, einnahmen, ausgaben, liquiditaet);
+		buildBurnChart(labels, burnrate);
+	}
+}
+
+function row(label, val, valClass) {
+	return '<div class="fd-row"><span class="fd-row-label">' + label + '</span><span class="fd-row-val ' + (valClass || '') + '">' + val + '</span></div>';
+}
+function rowTotal(label, val, valClass) {
+	return '<div class="fd-row fd-row-total"><span class="fd-row-label">' + label + '</span><span class="fd-row-val ' + (valClass || '') + '">' + val + '</span></div>';
+}
+
+function buildGVChart(labels, einnahmen, ausgaben, liquiditaet) {
+	if (window.fd_charts && window.fd_charts.gv) { window.fd_charts.gv.destroy(); }
+	var ctx = document.getElementById('fd-chart-gv');
+	if (!ctx) return;
+	$('#fd-legend-gv').html(
+		'<span><span class="fd-dot" style="background:#639922"></span>Einnahmen</span>' +
+		'<span><span class="fd-dot" style="background:#E24B4A"></span>Ausgaben</span>' +
+		'<span><span class="fd-dot" style="background:#378ADD"></span>Liquidität (Brutto)</span>'
+	);
+	window.fd_charts.gv = new Chart(ctx, {
+		type: 'line', data: {
+			labels: labels, datasets: [
+				{ label: 'Einnahmen', data: einnahmen, borderColor: '#639922', borderWidth: 2, pointRadius: 4, tension: 0.3, fill: false },
+				{ label: 'Ausgaben', data: ausgaben, borderColor: '#E24B4A', borderWidth: 2, pointRadius: 4, tension: 0.3, fill: false, borderDash: [4, 3] },
+				{ label: 'Liquidität (Brutto)', data: liquiditaet, borderColor: '#378ADD', borderWidth: 2.5, pointRadius: 4, tension: 0.3, fill: false, borderDash: [8, 3] }
+			]
+		}, options: chartOptions()
+	});
+}
+
+function buildBurnChart(labels, burnrate) {
+	if (window.fd_charts && window.fd_charts.burn) { window.fd_charts.burn.destroy(); }
+	var ctx = document.getElementById('fd-chart-burn');
+	if (!ctx) return;
+	$('#fd-legend-burn').html('<span><span class="fd-dot" style="background:#534AB7"></span>Burnrate/M Netto</span>');
+	window.fd_charts.burn = new Chart(ctx, {
+		type: 'line', data: {
+			labels: labels, datasets: [
+				{ label: 'Burnrate/M', data: burnrate, borderColor: '#534AB7', backgroundColor: 'rgba(83,74,183,0.08)', borderWidth: 2.5, pointRadius: 4, tension: 0.3, fill: true }
+			]
+		}, options: chartOptions()
+	});
+}
+
+function chartOptions() {
+	return {
+		responsive: true, maintainAspectRatio: false,
+		plugins: {
+			legend: { display: false }, tooltip: {
+				callbacks: {
+					label: function (ctx) {
+						return ctx.dataset.label + ': ' + new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(ctx.raw);
+					}
+				}
+			}
+		},
+		scales: {
+			x: { ticks: { color: '#888', font: { size: 11 } }, grid: { color: 'rgba(128,128,128,0.15)' } },
+			y: {
+				ticks: {
+					color: '#888', font: { size: 11 }, callback: function (v) {
+						return new Intl.NumberFormat('de-DE', { notation: 'compact', maximumFractionDigits: 0 }).format(v);
+					}
+				}, grid: { color: 'rgba(128,128,128,0.15)' }
+			}
+		}
+	};
+}
+
+function loadAngebote() {
+	frappe.call({
+		method: 'frappe.client.get_list',
+		args: {
+			doctype: 'Quotation', fields: ['company', 'net_total'],
+			filters: [['status', 'not in', ['Ordered', 'Partially Ordered', 'Cancelled', 'Lost']], ['docstatus', '=', 1]], limit: 500
+		},
+		callback: function (r) {
+			if (!r.message) return;
+			var byCompany = {}, total = 0, totalCount = 0;
+			r.message.forEach(function (q) {
+				var co = q.company || 'Unbekannt';
+				if (!byCompany[co]) byCompany[co] = { count: 0, total: 0 };
+				byCompany[co].count++; byCompany[co].total += q.net_total || 0;
+				total += q.net_total || 0; totalCount++;
+			});
+			var html = '';
+			Object.keys(byCompany).forEach(function (co) {
+				var d = byCompany[co];
+				html += '<div class="fd-row"><span class="fd-row-label">' + co + '<span class="fd-badge">' + d.count + '</span></span><span class="fd-row-val fd-color-blue">' + fmt(d.total) + '</span></div>';
+			});
+			html += '<div class="fd-row fd-row-total"><span class="fd-row-label">Total <span class="fd-badge">' + totalCount + '</span></span><span class="fd-row-val fd-color-green">' + fmt(total) + '</span></div>';
+			$('#fd-angebote-rows').html(html);
+		}
+	});
+}
+
+function loadOutstanding() {
+	frappe.call({
+		method: 'frappe.desk.query_report.run',
+		args: { report_name: 'Outstanding Report', filters: {}, ignore_prepared_report: true },
+		callback: function (r) {
+			if (!r.message || !r.message.result) { $('#fd-outstanding-rows').html('<div class="fd-loading">Keine Daten</div>'); return; }
+			var rows = r.message.result, unbilled = 0, invoicedNotPaid = 0;
+			rows.forEach(function (row) {
+				var type = row.type !== undefined ? row.type : row[10];
+				var uAmt = row.unbilled_netto !== undefined ? row.unbilled_netto : (row[7] || 0);
+				var iAmt = row.invoice_outstanding_netto !== undefined ? row.invoice_outstanding_netto : (row[8] || 0);
+				if (type === 'Not Yet Invoiced' || type === 'Partially Invoiced') unbilled += uAmt;
+				else if (type === 'Invoiced Not Paid') invoicedNotPaid += iAmt;
+			});
+			var total = unbilled + invoicedNotPaid;
+			$('#fd-outstanding-rows').html(
+				'<div class="fd-row"><span class="fd-row-label">Unbilled (nicht fakturiert)</span><span class="fd-row-val fd-color-blue">' + fmt(unbilled) + '</span></div>' +
+				'<div class="fd-row"><span class="fd-row-label">Invoiced not paid</span><span class="fd-row-val fd-color-amber">' + fmt(invoicedNotPaid) + '</span></div>' +
+				'<div class="fd-row fd-row-total"><span class="fd-row-label">Total Expected (Netto)</span><span class="fd-row-val fd-color-green">' + fmt(total) + '</span></div>'
+			);
+		}
+	});
+}

--- a/gallehr/page/finanz-dashboard/finanz_dashboard.json
+++ b/gallehr/page/finanz-dashboard/finanz_dashboard.json
@@ -1,0 +1,18 @@
+{
+ "creation": "2026-05-15 00:00:00.000000",
+ "doctype": "Page",
+ "modified": "2026-05-15 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Gallehr",
+ "name": "finanz-dashboard",
+ "owner": "Administrator",
+ "page_name": "finanz-dashboard",
+ "restrict_to_domain": "",
+ "roles": [
+  {
+   "role": "Dashboard Manager"
+  }
+ ],
+ "system_page": 0,
+ "title": "Finanz Dashboard"
+}

--- a/gallehr/public/js/finanz_dashboard.js
+++ b/gallehr/public/js/finanz_dashboard.js
@@ -1,0 +1,435 @@
+frappe.pages['finanz-dashboard'].on_page_load = function (wrapper) {
+	var page = frappe.ui.make_app_page({
+		parent: wrapper,
+		title: 'Finanz Dashboard',
+		single_column: true
+	});
+
+	$(frappe.render_template('finanz_dashboard', {})).appendTo(page.body);
+
+	window.fd_charts = {};
+	window.fd_chart_js_loaded = false;
+
+	var script = document.createElement('script');
+	script.src = '/assets/gallehr/js/chart.umd.min.js';
+	script.onload = function () {
+		window.fd_chart_js_loaded = true;
+		if (window.fd_chart_data) {
+			buildGVChart(window.fd_chart_data.labels, window.fd_chart_data.einnahmen, window.fd_chart_data.ausgaben, window.fd_chart_data.liquiditaet);
+			buildBurnChart(window.fd_chart_data.labels, window.fd_chart_data.burnrate);
+		}
+	};
+	document.head.appendChild(script);
+
+	bindEvents();
+	loadSnapshots(function () { loadAll(); });
+};
+
+function bindEvents() {
+	$(document).on('click', '.fd-apply-btn, .fd-refresh-btn', function () {
+		var aktuell = parseFloat($('#fd-aktuell').val());
+		var save = $('#fd-aktuell-save').is(':checked');
+		if (aktuell > 0 && save) {
+			saveSnapshot(aktuell, function () { loadAll(); loadSnapshots(); });
+		} else {
+			loadAll();
+		}
+	});
+
+	$(document).on('click', '.fd-snap-del-btn', function () {
+		var name = $(this).data('name');
+		frappe.confirm('Snapshot löschen?', function () {
+			frappe.call({
+				method: 'frappe.client.delete',
+				args: { doctype: 'Liquiditaet Snapshot', name: name },
+				callback: function () { loadSnapshots(function () { loadAll(); }); }
+			});
+		});
+	});
+
+	$(document).on('click', '.fd-snap-set-btn', function () {
+		var name = $(this).data('name');
+		var val = parseFloat($(this).data('val'));
+		setDefaultSnapshot(name, val);
+	});
+}
+
+function getFilters() {
+	return {
+		jahr: $('#fd-jahr').val() || '2026',
+		aktuell_liquiditaet: parseFloat($('#fd-aktuell').val()) || 0,
+		start_liquiditaet: parseFloat($('#fd-liq').val()) || 0,
+		angebotsumwandlung: parseFloat($('#fd-umwandlung').val()) || 30,
+		avg_aus_tag_manuell: parseFloat($('#fd-burnrate').val()) || 0
+	};
+}
+
+function fmt(val, decimals) {
+	if (val === null || val === undefined || isNaN(val)) return '—';
+	decimals = decimals !== undefined ? decimals : 0;
+	return new Intl.NumberFormat('de-DE', {
+		style: 'currency', currency: 'EUR',
+		minimumFractionDigits: decimals, maximumFractionDigits: decimals
+	}).format(val);
+}
+
+function fmtN(val, decimals) {
+	if (val === null || val === undefined || isNaN(val)) return '—';
+	decimals = decimals !== undefined ? decimals : 1;
+	return new Intl.NumberFormat('de-DE', {
+		minimumFractionDigits: decimals, maximumFractionDigits: decimals
+	}).format(val);
+}
+
+function fmtDt(dt) {
+	if (!dt) return '—';
+	return frappe.datetime.str_to_user(dt.substring(0, 16));
+}
+
+// ── Snapshot persistence ──────────────────────────────────────────────────────
+
+function loadSnapshots(cb) {
+	frappe.call({
+		method: 'frappe.client.get_value',
+		args: { doctype: 'DocType', filters: { name: 'Liquiditaet Snapshot' }, fieldname: 'name' },
+		callback: function (r) {
+			if (!r.message || !r.message.name) {
+				$('#fd-snap-rows').html('<div class="fd-loading">Snapshots nicht verfügbar (bench migrate ausstehend)</div>');
+				if (cb) cb();
+				return;
+			}
+			frappe.call({
+				method: 'frappe.client.get_list',
+				args: {
+					doctype: 'Liquiditaet Snapshot',
+					fields: ['name', 'kontostand_brutto', 'datum', 'als_standard', 'notiz'],
+					order_by: 'datum desc',
+					limit: 50
+				},
+				callback: function (r) {
+					var snaps = r.message || [];
+					renderSnapshotTable(snaps);
+					var aktuelField = $('#fd-aktuell');
+					if (!aktuelField.val()) {
+						var def = null;
+						snaps.forEach(function (s) { if (s.als_standard) def = s; });
+						if (def) {
+							aktuelField.val(def.kontostand_brutto);
+							showNotice('Standard-Snapshot vom ' + fmtDt(def.datum) + ' geladen (' + fmt(def.kontostand_brutto) + ')', 'info');
+						}
+					}
+					if (cb) cb();
+				}
+			});
+		}
+	});
+}
+
+function saveSnapshot(val, cb) {
+	// Clear existing defaults first, then create new
+	frappe.call({
+		method: 'frappe.client.get_list',
+		args: { doctype: 'Liquiditaet Snapshot', filters: { als_standard: 1 }, fields: ['name'], limit: 50 },
+		callback: function (r) {
+			var prev = r.message || [];
+			var chain = prev.length;
+
+			function createNew() {
+				frappe.call({
+					method: 'frappe.client.insert',
+					args: {
+						doc: {
+							doctype: 'Liquiditaet Snapshot',
+							kontostand_brutto: val,
+							datum: frappe.datetime.now_datetime(),
+							als_standard: 1
+						}
+					},
+					callback: function () {
+						showNotice('Snapshot gespeichert und als Standard gesetzt (' + fmt(val) + ')', 'saved');
+						if (cb) cb();
+					}
+				});
+			}
+
+			if (chain === 0) {
+				createNew();
+			} else {
+				var done = 0;
+				prev.forEach(function (p) {
+					frappe.call({
+						method: 'frappe.client.set_value',
+						args: { doctype: 'Liquiditaet Snapshot', name: p.name, fieldname: 'als_standard', value: 0 },
+						callback: function () { done++; if (done === chain) createNew(); }
+					});
+				});
+			}
+		}
+	});
+}
+
+function setDefaultSnapshot(name, val) {
+	// Clear all defaults, set this one, prefill field
+	frappe.call({
+		method: 'frappe.client.get_list',
+		args: { doctype: 'Liquiditaet Snapshot', filters: { als_standard: 1 }, fields: ['name'], limit: 50 },
+		callback: function (r) {
+			var prev = r.message || [];
+			var done = 0;
+			var total = prev.length;
+
+			function finish() {
+				frappe.call({
+					method: 'frappe.client.set_value',
+					args: { doctype: 'Liquiditaet Snapshot', name: name, fieldname: 'als_standard', value: 1 },
+					callback: function () {
+						$('#fd-aktuell').val(val);
+						showNotice('Standard gesetzt: ' + fmt(val), 'saved');
+						loadSnapshots(function () { loadAll(); });
+					}
+				});
+			}
+
+			if (total === 0) { finish(); return; }
+			prev.forEach(function (p) {
+				frappe.call({
+					method: 'frappe.client.set_value',
+					args: { doctype: 'Liquiditaet Snapshot', name: p.name, fieldname: 'als_standard', value: 0 },
+					callback: function () { done++; if (done === total) finish(); }
+				});
+			});
+		}
+	});
+}
+
+function renderSnapshotTable(snaps) {
+	if (!snaps.length) {
+		$('#fd-snap-rows').html('<div class="fd-loading">Keine Snapshots vorhanden</div>');
+		return;
+	}
+	var html = '<table class="fd-snap-table">' +
+		'<thead><tr>' +
+		'<th>Datum</th><th>Kontostand Brutto</th><th>Standard</th><th style="text-align:right">Aktionen</th>' +
+		'</tr></thead><tbody>';
+	snaps.forEach(function (s) {
+		var stdBadge = s.als_standard
+			? '<span class="fd-snap-std-badge">Standard</span>'
+			: '<button class="fd-snap-set-btn" data-name="' + s.name + '" data-val="' + s.kontostand_brutto + '">Als Standard</button>';
+		html += '<tr>' +
+			'<td>' + fmtDt(s.datum) + '</td>' +
+			'<td class="val">' + fmt(s.kontostand_brutto) + '</td>' +
+			'<td class="std">' + stdBadge + '</td>' +
+			'<td class="act"><button class="fd-snap-del-btn fd-snap-del" data-name="' + s.name + '" title="Löschen">✕</button></td>' +
+			'</tr>';
+	});
+	html += '</tbody></table>';
+	$('#fd-snap-rows').html(html);
+}
+
+function showNotice(msg, type) {
+	$('#fd-snap-notice').removeClass('info saved').addClass(type).text(msg).show();
+	setTimeout(function () { $('#fd-snap-notice').fadeOut(400); }, 4000);
+}
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+function loadAll() {
+	loadReport();
+	loadAngebote();
+	loadOutstanding();
+}
+
+function loadReport() {
+	var filters = getFilters();
+	frappe.call({
+		method: 'frappe.desk.query_report.run',
+		args: { report_name: 'Finanz Dashboard', filters: filters, ignore_prepared_report: true },
+		callback: function (r) {
+			if (!r.message) return;
+			processReport(r.message.columns, r.message.result, filters.jahr);
+		}
+	});
+}
+
+function processReport(columns, rows, jahr) {
+	var MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'];
+	var monthlyRows = [];
+	var prognoseMap = {};
+
+	(rows || []).forEach(function (row) {
+		var monat = row.monat !== undefined ? row.monat : row[0];
+		var yearVal = row.jahr !== undefined ? row.jahr : row[1];
+		if (String(yearVal) === String(jahr) && MONTHS.indexOf(monat) !== -1) {
+			monthlyRows.push(row);
+		} else if (!yearVal && monat && monat !== '---') {
+			prognoseMap[monat] = row;
+		}
+	});
+
+	function peur(label) {
+		var found = null;
+		Object.keys(prognoseMap).forEach(function (k) { if (k.indexOf(label) !== -1) found = prognoseMap[k]; });
+		return found ? (found.prognose_eur !== undefined ? found.prognose_eur : (found[2] || 0)) : 0;
+	}
+	function pzahl(label) {
+		var found = null;
+		Object.keys(prognoseMap).forEach(function (k) { if (k.indexOf(label) !== -1) found = prognoseMap[k]; });
+		return found ? (found.prognose_zahl !== undefined ? found.prognose_zahl : (found[3] || 0)) : 0;
+	}
+
+	var ist = peur('Umsatz Ist');
+	var soll = peur('Umsatz Soll');
+	var vorrLuecke = peur('Vorraussichtliche');
+	var liqBrutto = peur('Liquiditaet aktuell');
+	var burnTag = peur('Burnrate/Tag verwendet');
+	var burnM = burnTag * 30;
+	var tage = pzahl('Tage ohne');
+	var monate = pzahl('Monate ohne');
+
+	var lueckeClass = vorrLuecke > 0 ? 'fd-color-red' : 'fd-color-green';
+	$('#fd-umsatz-rows').html(
+		row('Umsatz Ist (YTD)', fmt(ist), 'fd-color-green') +
+		row('Umsatz Soll', fmt(soll), 'fd-color-purple') +
+		rowTotal('Vorr. Umsatzlücke', fmt(vorrLuecke), lueckeClass)
+	);
+	$('#fd-liq-rows').html(
+		row('Liquidität aktuell (Brutto/Kontostand)', fmt(liqBrutto), 'fd-color-blue') +
+		row('Tage ohne Zahlung', fmtN(tage, 0) + ' Tage / ' + fmtN(monate, 1) + ' Monate', 'fd-color-amber') +
+		row('Burnrate / Tag (Netto)', fmt(burnTag, 2), 'fd-color-purple') +
+		rowTotal('Burnrate / Monat (Netto)', fmt(burnM), 'fd-color-purple')
+	);
+
+	var activeMonths = monthlyRows.filter(function (r) {
+		var ein = r.einnahmen_brutto !== undefined ? r.einnahmen_brutto : (r[4] || 0);
+		var aus = r.ausgaben_brutto !== undefined ? r.ausgaben_brutto : (r[5] || 0);
+		return ein > 0 || aus > 0;
+	});
+	var labels = activeMonths.map(function (r) { return r.monat !== undefined ? r.monat : r[0]; });
+	var einnahmen = activeMonths.map(function (r) { return r.einnahmen_brutto !== undefined ? r.einnahmen_brutto : (r[4] || 0); });
+	var ausgaben = activeMonths.map(function (r) { return r.ausgaben_brutto !== undefined ? r.ausgaben_brutto : (r[5] || 0); });
+	var liquiditaet = activeMonths.map(function (r) { return r.liquiditaet !== undefined ? r.liquiditaet : (r[7] || 0); });
+	var burnrate = activeMonths.map(function (r) { return r.burnrate_m !== undefined ? r.burnrate_m : (r[12] || 0); });
+
+	window.fd_chart_data = { labels: labels, einnahmen: einnahmen, ausgaben: ausgaben, liquiditaet: liquiditaet, burnrate: burnrate };
+	if (window.fd_chart_js_loaded) {
+		buildGVChart(labels, einnahmen, ausgaben, liquiditaet);
+		buildBurnChart(labels, burnrate);
+	}
+}
+
+function row(label, val, valClass) {
+	return '<div class="fd-row"><span class="fd-row-label">' + label + '</span><span class="fd-row-val ' + (valClass || '') + '">' + val + '</span></div>';
+}
+function rowTotal(label, val, valClass) {
+	return '<div class="fd-row fd-row-total"><span class="fd-row-label">' + label + '</span><span class="fd-row-val ' + (valClass || '') + '">' + val + '</span></div>';
+}
+
+function buildGVChart(labels, einnahmen, ausgaben, liquiditaet) {
+	if (window.fd_charts && window.fd_charts.gv) { window.fd_charts.gv.destroy(); }
+	var ctx = document.getElementById('fd-chart-gv');
+	if (!ctx) return;
+	$('#fd-legend-gv').html(
+		'<span><span class="fd-dot" style="background:#639922"></span>Einnahmen</span>' +
+		'<span><span class="fd-dot" style="background:#E24B4A"></span>Ausgaben</span>' +
+		'<span><span class="fd-dot" style="background:#378ADD"></span>Liquidität (Brutto)</span>'
+	);
+	window.fd_charts.gv = new Chart(ctx, {
+		type: 'line', data: {
+			labels: labels, datasets: [
+				{ label: 'Einnahmen', data: einnahmen, borderColor: '#639922', borderWidth: 2, pointRadius: 4, tension: 0.3, fill: false },
+				{ label: 'Ausgaben', data: ausgaben, borderColor: '#E24B4A', borderWidth: 2, pointRadius: 4, tension: 0.3, fill: false, borderDash: [4, 3] },
+				{ label: 'Liquidität (Brutto)', data: liquiditaet, borderColor: '#378ADD', borderWidth: 2.5, pointRadius: 4, tension: 0.3, fill: false, borderDash: [8, 3] }
+			]
+		}, options: chartOptions()
+	});
+}
+
+function buildBurnChart(labels, burnrate) {
+	if (window.fd_charts && window.fd_charts.burn) { window.fd_charts.burn.destroy(); }
+	var ctx = document.getElementById('fd-chart-burn');
+	if (!ctx) return;
+	$('#fd-legend-burn').html('<span><span class="fd-dot" style="background:#534AB7"></span>Burnrate/M Netto</span>');
+	window.fd_charts.burn = new Chart(ctx, {
+		type: 'line', data: {
+			labels: labels, datasets: [
+				{ label: 'Burnrate/M', data: burnrate, borderColor: '#534AB7', backgroundColor: 'rgba(83,74,183,0.08)', borderWidth: 2.5, pointRadius: 4, tension: 0.3, fill: true }
+			]
+		}, options: chartOptions()
+	});
+}
+
+function chartOptions() {
+	return {
+		responsive: true, maintainAspectRatio: false,
+		plugins: {
+			legend: { display: false }, tooltip: {
+				callbacks: {
+					label: function (ctx) {
+						return ctx.dataset.label + ': ' + new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(ctx.raw);
+					}
+				}
+			}
+		},
+		scales: {
+			x: { ticks: { color: '#888', font: { size: 11 } }, grid: { color: 'rgba(128,128,128,0.15)' } },
+			y: {
+				ticks: {
+					color: '#888', font: { size: 11 }, callback: function (v) {
+						return new Intl.NumberFormat('de-DE', { notation: 'compact', maximumFractionDigits: 0 }).format(v);
+					}
+				}, grid: { color: 'rgba(128,128,128,0.15)' }
+			}
+		}
+	};
+}
+
+function loadAngebote() {
+	frappe.call({
+		method: 'frappe.client.get_list',
+		args: {
+			doctype: 'Quotation', fields: ['company', 'net_total'],
+			filters: [['status', 'not in', ['Ordered', 'Partially Ordered', 'Cancelled', 'Lost']], ['docstatus', '=', 1]], limit: 500
+		},
+		callback: function (r) {
+			if (!r.message) return;
+			var byCompany = {}, total = 0, totalCount = 0;
+			r.message.forEach(function (q) {
+				var co = q.company || 'Unbekannt';
+				if (!byCompany[co]) byCompany[co] = { count: 0, total: 0 };
+				byCompany[co].count++; byCompany[co].total += q.net_total || 0;
+				total += q.net_total || 0; totalCount++;
+			});
+			var html = '';
+			Object.keys(byCompany).forEach(function (co) {
+				var d = byCompany[co];
+				html += '<div class="fd-row"><span class="fd-row-label">' + co + '<span class="fd-badge">' + d.count + '</span></span><span class="fd-row-val fd-color-blue">' + fmt(d.total) + '</span></div>';
+			});
+			html += '<div class="fd-row fd-row-total"><span class="fd-row-label">Total <span class="fd-badge">' + totalCount + '</span></span><span class="fd-row-val fd-color-green">' + fmt(total) + '</span></div>';
+			$('#fd-angebote-rows').html(html);
+		}
+	});
+}
+
+function loadOutstanding() {
+	frappe.call({
+		method: 'frappe.desk.query_report.run',
+		args: { report_name: 'Outstanding Report', filters: {}, ignore_prepared_report: true },
+		callback: function (r) {
+			if (!r.message || !r.message.result) { $('#fd-outstanding-rows').html('<div class="fd-loading">Keine Daten</div>'); return; }
+			var rows = r.message.result, unbilled = 0, invoicedNotPaid = 0;
+			rows.forEach(function (row) {
+				var type = row.type !== undefined ? row.type : row[10];
+				var uAmt = row.unbilled_netto !== undefined ? row.unbilled_netto : (row[7] || 0);
+				var iAmt = row.invoice_outstanding_netto !== undefined ? row.invoice_outstanding_netto : (row[8] || 0);
+				if (type === 'Not Yet Invoiced' || type === 'Partially Invoiced') unbilled += uAmt;
+				else if (type === 'Invoiced Not Paid') invoicedNotPaid += iAmt;
+			});
+			var total = unbilled + invoicedNotPaid;
+			$('#fd-outstanding-rows').html(
+				'<div class="fd-row"><span class="fd-row-label">Unbilled (nicht fakturiert)</span><span class="fd-row-val fd-color-blue">' + fmt(unbilled) + '</span></div>' +
+				'<div class="fd-row"><span class="fd-row-label">Invoiced not paid</span><span class="fd-row-val fd-color-amber">' + fmt(invoicedNotPaid) + '</span></div>' +
+				'<div class="fd-row fd-row-total"><span class="fd-row-label">Total Expected (Netto)</span><span class="fd-row-val fd-color-green">' + fmt(total) + '</span></div>'
+			);
+		}
+	});
+}


### PR DESCRIPTION
…lic/js
Fix: page files at wrong nesting level, JS not served correctly on Frappe Cloud

## Problem
Page files were placed at gallehr/gallehr/page/finanz_dashboard/ instead
of gallehr/page/finanz-dashboard/ — one extra gallehr/ nesting level,
same issue as the DocType folder earlier. This caused Frappe Cloud to
serve a stale cached version of finanz_dashboard.js from assets instead
of the updated file, so all JS changes (Brutto/Kontostand label,
liquiditaet_netto removal, snapshot logic) were never live.

Additionally finanz_dashboard.js was missing from public/js/ which is
where the asset pipeline expects it for /assets/gallehr/js/ serving.

## Fix
- Moved all page files to correct path: gallehr/page/finanz-dashboard/
- Added finanz_dashboard.js to gallehr/public/js/ so Frappe Cloud build
  picks it up correctly

## After deploy
No bench migrate needed — JS/CSS/HTML assets only.