### PR TITLE
fix(liquiditaet-snapshot): add custom=1, scope fixture filter, add Sy…

### DIFF
--- a/gallehr/doctype/liquiditaet_snapshot/liquiditaet_snapshot.json
+++ b/gallehr/doctype/liquiditaet_snapshot/liquiditaet_snapshot.json
@@ -1,66 +1,78 @@
 {
-  "actions": [],
-  "allow_rename": 0,
-  "autoname": "format:LIQ-SNAP-{YYYY}-{MM}-{DD}-{######}",
-  "creation": "2026-05-18 00:00:00.000000",
-  "doctype": "DocType",
-  "editable_grid": 1,
-  "engine": "InnoDB",
-  "field_order": [
-    "kontostand_brutto",
-    "datum",
-    "als_standard",
-    "notiz"
-  ],
-  "fields": [
-    {
-      "fieldname": "kontostand_brutto",
-      "fieldtype": "Currency",
-      "in_list_view": 1,
-      "label": "Kontostand Brutto",
-      "reqd": 1
-    },
-    {
-      "fieldname": "datum",
-      "fieldtype": "Datetime",
-      "in_list_view": 1,
-      "label": "Datum",
-      "reqd": 1
-    },
-    {
-      "fieldname": "als_standard",
-      "fieldtype": "Check",
-      "in_list_view": 1,
-      "label": "Als Standard verwenden"
-    },
-    {
-      "fieldname": "notiz",
-      "fieldtype": "Small Text",
-      "label": "Notiz"
-    }
-  ],
-  "links": [],
-  "modified": "2026-05-18 00:00:00.000000",
-  "modified_by": "Administrator",
-  "module": "Gallehr",
-  "name": "Liquiditaet Snapshot",
-  "naming_rule": "Expression",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Dashboard Manager",
-      "share": 1,
-      "write": 1
-    }
-  ],
-  "sort_field": "datum",
-  "sort_order": "DESC",
-  "track_changes": 1
+ "actions": [],
+ "autoname": "format:LIQ-SNAP-{YYYY}-{MM}-{DD}-{######}",
+ "creation": "2026-05-19 00:00:00.000000",
+ "custom": 1,
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "kontostand_brutto",
+  "datum",
+  "als_standard",
+  "notiz"
+ ],
+ "fields": [
+  {
+   "fieldname": "kontostand_brutto",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Kontostand Brutto",
+   "reqd": 1
+  },
+  {
+   "fieldname": "datum",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "Datum",
+   "reqd": 1
+  },
+  {
+   "fieldname": "als_standard",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Als Standard verwenden"
+  },
+  {
+   "fieldname": "notiz",
+   "fieldtype": "Small Text",
+   "label": "Notiz"
+  }
+ ],
+ "links": [],
+ "modified": "2026-05-19 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Gallehr",
+ "name": "Liquiditaet Snapshot",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Dashboard Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "datum",
+ "sort_order": "DESC",
+ "track_changes": 1
 }

--- a/gallehr/hooks.py
+++ b/gallehr/hooks.py
@@ -7,31 +7,28 @@ app_license = "MIT"
 
 # include js in doctype views
 doctype_js = {
-    "Contact" : "public/js/contact.js",
-    "Leave Application" : "public/js/leave_application.js",
-    # "Sales Order" : "public/js/sales_order.js",
-    "Web Form" : "public/js/web_form.js",
+    "Contact": "public/js/contact.js",
+    "Leave Application": "public/js/leave_application.js",
+    # "Sales Order": "public/js/sales_order.js",
+    "Web Form": "public/js/web_form.js",
 }
+
 fixtures = [
-    {"dt": "Print Format", "filters": 
-        [
-            ["module", "=", "Gallehr"],
-            ["standard", "!=", "Yes"]
-        ]
-    },
-    {"dt": "Custom Field", "filters":
-        [
-            ["module", "=", "Gallehr"]
-        ]
-    },
-    {"dt": "Property Setter", "filters":
-        [
-            ["module", "=", "Gallehr"]
-        ]
-    },
-    {"dt": "DocType", "filters": [["module", "=", "Gallehr"]]}
+    {"dt": "Print Format", "filters": [
+        ["module", "=", "Gallehr"],
+        ["standard", "!=", "Yes"]
+    ]},
+    {"dt": "Custom Field", "filters": [
+        ["module", "=", "Gallehr"]
+    ]},
+    {"dt": "Property Setter", "filters": [
+        ["module", "=", "Gallehr"]
+    ]},
+    {"dt": "DocType", "filters": [
+        ["name", "=", "Liquiditaet Snapshot"]
+    ]}
 ]
 
 override_whitelisted_methods = {
-	"frappe.desk.search.search_link": "gallehr.override.search.search_link",
+    "frappe.desk.search.search_link": "gallehr.override.search.search_link",
 }


### PR DESCRIPTION
…stem Manager permission
Fix: Liquiditaet Snapshot fixture import failing on deploy

## Problems
1. liquiditaet_snapshot.json missing "custom": 1 → migrate threw
   CannotCreateStandardDoctypeError on every deploy since developer mode
   is not enabled on Frappe Cloud
2. hooks.py DocType fixture filter was ["module","=","Gallehr"] →
   imported ALL Gallehr DocTypes including ones that could fail the same
   way in the future
3. Only Dashboard Manager had permissions → users with System Manager
   role (e.g. Ulrich) were blocked with "No permission" error on the
   dashboard

## Fixes
- Added "custom": 1 to liquiditaet_snapshot.json so it can be imported
  without developer mode on any environment
- Scoped DocType fixture filter in hooks.py to
  ["name","=","Liquiditaet Snapshot"] — explicit, safe, no risk of
  pulling in other DocTypes
- Added System Manager role to DocType permissions

## After deploy
- bench migrate will update the existing DocType on live (already
  created via Server Script) — no conflict, no data loss
- No manual steps required